### PR TITLE
Use `RemoteClientDataTransfer` with `BagCourier` to reduce copies (DBAI-26)

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -3,7 +3,6 @@
 # Settings
 # One of info, debug, error, warn, trace, fatal
 LogLevel: "info"
-SourceDir: "./source"
 WorkingDir: "./prep"
 ExportDir: "./export"
 # Determines whether the process skips sending bag(s)

--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -114,15 +114,11 @@ module Archivematica
       name:,
       api:,
       location_uuid:,
-      remote_client:,
-      source_dir:,
       object_size_limit:
     )
       @name = name
       @api = api
       @location_uuid = location_uuid
-      @remote_client = remote_client
-      @source_dir = source_dir
       @object_size_limit = object_size_limit
     end
 
@@ -138,13 +134,6 @@ module Archivematica
         logger.info("Inner bag name: #{inner_bag_dir_name}")
         ingest_dir_name = inner_bag_dir_name.gsub("-" + package.uuid, "")
         logger.info("Directory name on Archivematica ingest: #{ingest_dir_name}")
-
-        # Copy file to local source directory, using SFTP or shared mount
-        @remote_client.retrieve_from_path(
-          remote_path: package.path,
-          local_path: @source_dir
-        )
-
         object_metadata = DigitalObject::ObjectMetadata.new(
           id: package.uuid,
           title: "#{package.uuid} / #{ingest_dir_name}",
@@ -152,7 +141,7 @@ module Archivematica
           description: NA
         )
         DigitalObject::DigitalObject.new(
-          path: File.join(@source_dir, inner_bag_dir_name),
+          remote_path: package.path,
           metadata: object_metadata,
           context: @name
         )

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -6,7 +6,6 @@ module Config
   SettingsConfig = Struct.new(
     "SettingsConfig",
     :log_level,
-    :source_dir,
     :working_dir,
     :export_dir,
     :dry_run,
@@ -160,7 +159,6 @@ module Config
       Config.new(
         settings: SettingsConfig.new(
           log_level: verify_string("LogLevel", data["LogLevel"]).to_sym,
-          source_dir: verify_string("SourceDir", data["SourceDir"]),
           working_dir: verify_string("WorkingDir", data["WorkingDir"]),
           export_dir: verify_string("ExportDir", data["ExportDir"]),
           dry_run: verify_boolean("DryRun", data["DryRun"]),

--- a/lib/data_transfer.rb
+++ b/lib/data_transfer.rb
@@ -6,7 +6,7 @@ module DataTransfer
   end
 
   class RemoteClientDataTransfer < DataTransferBase
-    def initialize(remote_client:, remote_path:)
+    def initialize(remote_client:, remote_path: nil)
       @remote_client = remote_client
       @remote_path = remote_path
     end

--- a/lib/data_transfer.rb
+++ b/lib/data_transfer.rb
@@ -1,22 +1,7 @@
-require_relative "remote_client"
-
 module DataTransfer
   class DataTransferBase
     def transfer(target_dir)
       raise NotImplementedError
-    end
-  end
-
-  class DirDataTransfer < DataTransferBase
-    attr_reader :source_dir
-
-    def initialize(source_dir)
-      @source_dir = source_dir
-    end
-
-    def transfer(target_dir)
-      RemoteClient::FileSystemRemoteClient.new(@source_dir)
-        .retrieve_from_path(local_path: target_dir)
     end
   end
 

--- a/lib/data_transfer.rb
+++ b/lib/data_transfer.rb
@@ -19,4 +19,17 @@ module DataTransfer
         .retrieve_from_path(local_path: target_dir)
     end
   end
+
+  class RemoteClientDataTransfer < DataTransferBase
+    def initialize(remote_client:, remote_path:)
+      @remote_client = remote_client
+      @remote_path = remote_path
+    end
+
+    def transfer(target_dir)
+      @remote_client.retrieve_from_path(
+        remote_path: @remote_path, local_path: target_dir
+      )
+    end
+  end
 end

--- a/lib/digital_object.rb
+++ b/lib/digital_object.rb
@@ -1,7 +1,7 @@
 module DigitalObject
   DigitalObject = Struct.new(
     "DigitalObject",
-    :path,
+    :remote_path,
     :metadata,
     :context,
     keyword_init: true

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -41,24 +41,26 @@ class DarkBlueJob
         type: remote_config.type,
         settings: remote_config.settings
       )
-      digital_objects += Archivematica::ArchivematicaService.new(
+
+      digital_objects = Archivematica::ArchivematicaService.new(
         name: arch_config.name,
         api: arch_api,
         location_uuid: api_config.location_uuid,
-        remote_client: remote_client,
-        source_dir: @source_dir,
         object_size_limit: @object_size_limit
       ).get_digital_objects
-    end
-    logger.debug(digital_objects)
+      logger.debug(digital_objects)
 
-    digital_objects.each do |digital_object|
-      courier = @dispatcher.dispatch(
-        object_metadata: digital_object.metadata,
-        data_transfer: DataTransfer::DirDataTransfer.new(digital_object.path),
-        context: digital_object.context
-      )
-      courier.deliver
+      digital_objects.each do |obj|
+        courier = @dispatcher.dispatch(
+          object_metadata: obj.metadata,
+          data_transfer: DataTransfer::RemoteClientDataTransfer.new(
+            remote_client: remote_client,
+            remote_path: obj.remote_path
+          ),
+          context: obj.context
+        )
+        courier.deliver
+      end
     end
 
     logger.info("Events")

--- a/run_example.rb
+++ b/run_example.rb
@@ -17,16 +17,13 @@ target_client = RemoteClient::RemoteClientFactory.from_config(
   settings: config.target_remote.settings
 )
 
-# Use a RemoteClient to move the object(s) to the source directory if it's in a remote
-# location
-# source_client = RemoteClient::RemoteClientFactory.from_config(
-#   type: config.source_remote.type,
-#   settings: config.source_remote.settings
-# )
-# source_client.retrieve_from_path(
-#   remote_path: "some/remote/path",
-#   local_path: config.settings.source_dir
-# )
+# A RemoteClient will be used to copy your object into the bag
+source_client = RemoteClient::RemoteClientFactory.from_config(
+  type: :file_system,
+  settings: Config::FileSystemRemoteConfig.new(
+    remote_path: "some/source/path/for/object"
+  )
+)
 
 dispatcher = Dispatcher::APTrustDispatcher.new(
   settings: config.settings,
@@ -43,8 +40,9 @@ object_metadata = Dispatcher::ObjectMetadata.new(
 
 courier = dispatcher.dispatch(
   object_metadata: object_metadata,
-  data_transfer: DataTransfer::DirDataTransfer.new(
-    File.join(config.settings.source_dir, "some_directory")
+  data_transfer: DataTransfer::RemoteClientDataTransfer.new(
+    source_client
+    # remote_path: # use this if your object isn't at the root of the remote
   ),
   context: "somecontext"
 )

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -199,8 +199,6 @@ class ArchivematicaServiceTest < Minitest::Test
       name: "test",
       api: @mock_api,
       location_uuid: @location_uuid,
-      remote_client: @mock_remote_client,
-      source_dir: @source_dir,
       object_size_limit: @object_size_limit
     )
 
@@ -221,14 +219,6 @@ class ArchivematicaServiceTest < Minitest::Test
     ]
 
     @mock_api.expect(:get_packages, packages, location_uuid: @location_uuid)
-    packages.each_with_index do |p, i|
-      @mock_remote_client.expect(
-        :retrieve_from_path,
-        true,
-        remote_path: packages[i].path,
-        local_path: @source_dir
-      )
-    end
     digital_objects = service.get_digital_objects
 
     # filters out larger bag
@@ -236,7 +226,7 @@ class ArchivematicaServiceTest < Minitest::Test
 
     first_package = packages[0]
     expected = DigitalObject.new(
-      path: "test_source/identifier-one-#{uuids[0]}",
+      remote_path: first_package.path,
       metadata: ObjectMetadata.new(
         id: first_package.uuid,
         title: "#{first_package.uuid} / identifier-one",


### PR DESCRIPTION
This PR aims to resolve [DBAI-26](https://mlit.atlassian.net/jira/software/projects/DBAI/boards/89). Here's a quick rundown of the changes and the rationale.

1) Create a `RemoteClientDataTransfer` object so any `RemoteClient` can be used to copy directly into a bag being created. This strategy eliminates one extra copy from the source directory to the bag, saving compute resources and limiting opportunities for corruption. It also makes the status events for `copying` and `copied` more meaningful.
2) As part of changes in 1), remove `remote_client` as a parameter for `ArchivematicaService` and instead pass it to `RemoteClientDataTransfer` when dispatching. I also changed the process logic so that objects from each Archivematica instance are handled separately, rather than in a single loop.
3) Remove `source_dir` from the configuration. While it might be useful to have another local staging location, this shouldn't be required by the process.